### PR TITLE
Adopt Gymnasium API for TradingEnvironment

### DIFF
--- a/trading_environment.py
+++ b/trading_environment.py
@@ -1,7 +1,10 @@
 import numpy as np
 from collections import deque
+import gymnasium
+import gymnasium as gym
 
-class TradingEnvironment:
+
+class TradingEnvironment(gymnasium.Env):
     def __init__(self, data_df, is_training=True, fee_rate=0.001,
                  variance_window=30, out_market_penalty=0.1):
         self.initial_balance = 100000.0
@@ -18,6 +21,12 @@ class TradingEnvironment:
         self.return_history = deque(maxlen=variance_window)
         self.time_out_market = 0
         self.out_market_penalty = out_market_penalty
+
+        # Gym spaces
+        self.action_space = gym.spaces.Discrete(3)
+        self.observation_space = gym.spaces.Box(
+            low=0.0, high=np.inf, shape=(3,), dtype=np.float32
+        )
 
     def get_observation(self):
         current_data = self.df.iloc[self.current_step]
@@ -77,7 +86,8 @@ class TradingEnvironment:
         }
         return self.get_observation(), reward, terminated, False, info
 
-    def reset(self):
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
         self.balance = float(self.initial_balance)
         self.shares_held = 0.0
         self.current_step = 0


### PR DESCRIPTION
## Summary
- Refactor `TradingEnvironment` to inherit from `gymnasium.Env`
- Define discrete action space and box observation space
- Update `reset` and `step` to follow latest Gymnasium API

## Testing
- `python -m py_compile trading_environment.py`
- `python - <<'PY'
import pandas as pd
from trading_environment import TradingEnvironment

df = pd.DataFrame({'Close': [100, 101, 102, 103]})

env = TradingEnvironment(df)
obs, info = env.reset()
obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b59e606b0c83338c415c500fc24e23