### PR TITLE
Rename trading environment module and export TradingEnv

### DIFF
--- a/trading_env.py
+++ b/trading_env.py
@@ -1,7 +1,7 @@
 import numpy as np
 from collections import deque
 
-class TradingEnvironment:
+class TradingEnv:
     def __init__(self, data_df, is_training=True, fee_rate=0.001,
                  variance_window=30, out_market_penalty=0.1):
         self.initial_balance = 100000.0
@@ -87,3 +87,9 @@ class TradingEnvironment:
         self.return_history.clear()
         self.time_out_market = 0
         return self.get_observation(), {}
+
+
+# Backwards compatibility with older imports
+TradingEnvironment = TradingEnv
+
+__all__ = ["TradingEnv", "TradingEnvironment"]


### PR DESCRIPTION
## Summary
- rename `trading_environment.py` to `trading_env.py`
- expose environment class as `TradingEnv` and keep `TradingEnvironment` alias

## Testing
- `python -m py_compile train.py trading_env.py`
- `python - <<'PY'
from train import make_env
import pandas as pd
df = pd.DataFrame({'Close':[100,101,102,103]})
fn = make_env(df, randomize=False)
print(type(fn()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b59e5d4b8c8333aad6d550822b0a05