### PR TITLE
Remove deterministic seeding

### DIFF
--- a/Copy_of_^TASI_SR_RL_Model_final(01092025).ipynb
+++ b/Copy_of_^TASI_SR_RL_Model_final(01092025).ipynb
@@ -112,7 +112,7 @@
       "Requirement already satisfied: pycparser in /usr/local/lib/python3.12/dist-packages (from cffi>=1.12.0->curl_cffi>=0.7->yfinance) (2.22)\n",
       "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from sympy>=1.13.3->torch<3.0,>=2.3->stable-baselines3) (1.3.0)\n",
       "Downloading stable_baselines3-2.7.0-py3-none-any.whl (187 kB)\n",
-      "\u001b[2K   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m187.2/187.2 kB\u001b[0m \u001b[31m10.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m187.2/187.2 kB\u001b[0m \u001b[31m10.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hInstalling collected packages: stable-baselines3\n",
       "Successfully installed stable-baselines3-2.7.0\n"
      ]
@@ -1857,8 +1857,8 @@
     "\n",
     "        return self.get_observation(), reward, terminated, truncated, info\n",
     "\n",
-    "    def reset(self, seed=None, options=None):\n",
-    "        super().reset(seed=seed)\n",
+    "    def reset(self, options=None):\n",
+    "        super().reset()\n",
     "        self.balance = float(self.initial_balance)\n",
     "        self.shares_held = 0.0\n",
     "        self.current_step = 0\n",
@@ -1898,7 +1898,6 @@
     "\n",
     "        # Create synthetic data if download fails\n",
     "        dates = pd.date_range(start='2020-01-01', end='2023-12-31', freq='B')\n",
-    "        np.random.seed(42)  # For reproducibility\n",
     "\n",
     "        # Create base price with trend and seasonality\n",
     "        base_price = np.linspace(10000, 12000, len(dates))\n",

--- a/trading_environment.py
+++ b/trading_environment.py
@@ -91,8 +91,8 @@ class TradingEnvironment(gym.Env):
         }
         return self.get_observation(), reward, terminated, False, info
 
-    def reset(self, seed=None, options=None):
-        super().reset(seed=seed)
+    def reset(self, options=None):
+        super().reset()
         self.balance = float(self.initial_balance)
         self.shares_held = 0.0
         self.current_step = 0


### PR DESCRIPTION
## Summary
- Drop seed parameter and super seed call from `TradingEnvironment.reset`
- Strip notebook of explicit `np.random.seed` usage for non-deterministic runs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a5bc499c8333bbc3098653fb1b39